### PR TITLE
レイアウトファイルのVuetify対応

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,11 @@
 <template>
-  <div>
-    <nuxt />
-  </div>
+  <v-app>
+    <v-navigation-drawer app></v-navigation-drawer>
+    <v-toolbar app></v-toolbar>
+    <v-content>
+      <nuxt />
+    </v-content>
+  </v-app>
 </template>
 
 <style>
@@ -22,34 +26,5 @@ html {
 *:after {
   box-sizing: border-box;
   margin: 0;
-}
-
-.button--green {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #3b8070;
-  color: #3b8070;
-  text-decoration: none;
-  padding: 10px 30px;
-}
-
-.button--green:hover {
-  color: #fff;
-  background-color: #3b8070;
-}
-
-.button--grey {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #35495e;
-  color: #35495e;
-  text-decoration: none;
-  padding: 10px 30px;
-  margin-left: 15px;
-}
-
-.button--grey:hover {
-  color: #fff;
-  background-color: #35495e;
 }
 </style>


### PR DESCRIPTION
## WHAT
`layout/default.vue` 内で<v-app/>タグで囲ってあげないと、Vuetifyのコンポーネント群がうまく機能しないので修正した。