### PR TITLE
Send credentials with /api/v1/queue request

### DIFF
--- a/api/main.ts
+++ b/api/main.ts
@@ -7,7 +7,7 @@ const instance = axios.create({
 
 export default {
   getQueue: async () => {
-    const res = await instance.get('/queue')
+    const res = await instance.get('/queue', { withCredentials: true })
     return res.data as GetQueueResponse
   },
   addTrack: async (trackURI: string) => {


### PR DESCRIPTION
## WHAT
`/api/v1/queue` へのリクエスト時にもcookieを送信する．

## WHY
sessionを導入したらこのエンドポイントも認証が必要になる．