### PR TITLE
Vuetifyを直接依存関係に追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "nuxt": "^2.8.1",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3",
-    "vue-property-decorator": "^8.2.1"
+    "vue-property-decorator": "^8.2.1",
+    "vuetify": "^1.5.16"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9901,7 +9901,7 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
-vuetify@^1.5.14:
+vuetify@^1.5.14, vuetify@^1.5.16:
   version "1.5.16"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.5.16.tgz#cc9d0199c389d64d15787ddc85ca47a28225eeee"
   integrity sha512-yBgOsfurKQkeS+l+rrTQZ2bFk0D9ezjHhkuVM5A/yVzcg62sY2nfYaq/H++uezBWC9WYFrp/5OmSocJQcWn9Qw==


### PR DESCRIPTION
## WHAT
vuetifyパッケージは、もともと@nuxtjs/vuetifyの依存関係として入っていたが、さらに直接の依存関係として追加した。

## WHY
こうしないとWebStormの補完が効かないため(@web-types/vuetifyだけ入れてもダメだった)