### PR TITLE
user-read-private scope を追加

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -9,6 +9,7 @@ export default {
     const authScopes = [
       'user-read-playback-state',
       'user-read-currently-playing',
+      'user-read-private',
       'user-modify-playback-state',
       'playlist-read-private',
       'playlist-modify-private'


### PR DESCRIPTION
## WHAT
[`user-read-private`](https://developer.spotify.com/documentation/general/guides/scopes/#user-read-private) scopeをSpotifyのログインリンクに追加．

## WHY
ユーザがpremiumかどうかをサーバ側で取得するのにこのscopeが必要．