### PR TITLE
WebStormにおいてコンポーネントのインポートがTS2307でエラーになる問題を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,12 @@
     "noImplicitAny": false
   },
   "include": [
-    "components/**/*.vue"
+    "api/*.ts",
+    "layouts/*.vue",
+    "components/**/*.vue",
+    "pages/*.vue",
+    "pages/**/**/*.vue",
+    "store/*.ts",
+    "store/**/*.ts"
   ]
 }


### PR DESCRIPTION
## WHY
WebStromで `@/components/` 以下の import 文が `TS237 Can't find module` のエラーを吐いていた。
 
## WHAT
`tsconfig.json` に `include` を指定することでエラーを解消する。