### PR TITLE
tsconfig.jsonのincludeをワイルドカードにする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,6 @@
     "noImplicitAny": false
   },
   "include": [
-    "api/*.ts",
-    "layouts/*.vue",
-    "components/**/*.vue",
-    "pages/*.vue",
-    "pages/**/**/*.vue",
-    "store/*.ts",
-    "store/**/*.ts"
+    "*"
   ]
 }


### PR DESCRIPTION
## Why
#61 が正しく動作していなかった。

## What
`include` を `*` にしてすべてマッチさせる。

`exclude` が指定されていないとき、 `node_module` と `dist` は自動で除外されるので変なものがincludeに含まれる問題はない。