### PR TITLE
フリープランで再生できないことを示すダイアログの修正

### DIFF
--- a/components/organisms/BanFreePlanDialog.vue
+++ b/components/organisms/BanFreePlanDialog.vue
@@ -9,10 +9,8 @@
         </p>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" flat @click="closeDialog"
-            >Upgrade Spotify Premium</v-btn
-          >
-          <v-btn color="primary" flat @click="closeDialog">Dismiss now</v-btn>
+          <v-btn color="primary" flat @click="closeDialog">Upgrade</v-btn>
+          <v-btn color="primary" flat @click="closeDialog">Dismiss</v-btn>
         </v-card-actions>
       </v-card-text>
     </v-card>


### PR DESCRIPTION
ボタンの文言が長かったため，スマホなどで見ると，ダイアログが見切れていた．ボタンの文言を短くして，画面内に収まるよう修正．
https://gyazo.com/0d2b108f0e1f3f98e6aa7ab952404a17