### PR TITLE
netlify.tomlを追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  publish = "dist/"
+  command = "yarn run build"
+
+[context.production]
+  environment = { BASE_URL = "https://here-songs.tomoyat1.com", BASE_WEBSOCKET_URL = "wss://here-songs.tomoyat1.com/api/v1" }


### PR DESCRIPTION
## WHAT
NetlifyのGUI側でv2-testを環境変数にセットした。
現状のmasterブランチに関するビルドは、以前の `https://here-songs.tomoyat1.com` で行うように `netlify.toml` を作成した。

## WHY
developブランチおよびデプロイプレビューはv2-testのサーバーに接続するようにしたいから