### PR TITLE
Implement WebSocket v2 API

### DIFF
--- a/models/SocketMessage.ts
+++ b/models/SocketMessage.ts
@@ -10,6 +10,10 @@ export interface NextTrackMessage {
   head: number
 }
 
+export interface PlayMessage {
+  type: 'PLAY'
+}
+
 export interface PauseMessage {
   type: 'PAUSE'
 }
@@ -18,8 +22,23 @@ export interface ResumeMessage {
   type: 'RESUME'
 }
 
+export interface InteruputMessage {
+  type: 'INTERRUPT'
+  track: Track
+}
+
+export interface ProgressMessage {
+  type: 'PROGRESS'
+  length: number
+  progress: number
+  remaining: number
+}
+
 export type SocketMessage =
   | AddTrackMessage
   | NextTrackMessage
+  | PlayMessage
   | PauseMessage
   | ResumeMessage
+  | InteruputMessage
+  | ProgressMessage

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -200,7 +200,7 @@ const nuxtConfig: NuxtConfiguration = {
   env: {
     BASE_URL: process.env.BASE_URL || 'http://localhost:8080',
     BASE_WEBSOCKET_URL:
-      process.env.BASE_WEBSOCKET_URL || 'ws://localhost:8080/api/v1',
+      process.env.BASE_WEBSOCKET_URL || 'ws://localhost:8080/api/v2',
     CLIENT_ID: '2d41ee0f36664938a4669dcf5e81a43f'
   }
 }

--- a/store/plugin/WebSocketPlugin.ts
+++ b/store/plugin/WebSocketPlugin.ts
@@ -4,27 +4,43 @@ import { SocketMessage } from '@/models/SocketMessage'
 const SOCKET_URL = `${process.env.BASE_WEBSOCKET_URL}/ws`
 
 const WebSocketPlugin = (store: any) => {
-  const socket = new WebSocket(SOCKET_URL)
-  socket.onmessage = (e: MessageEvent) => {
-    console.log(e.data)
-    const message = JSON.parse(e.data) as SocketMessage
-    switch (message.type) {
-      case 'ADDTRACK':
-        store.commit('currentSession/addTrack', message.track)
-        break
-      case 'NEXTTRACK':
-        store.commit('currentSession/nextTrack', message.head)
-        break
-      case 'PAUSE':
-        store.commit('currentSession/setPaused', true)
-        break
-      case 'RESUME':
-        store.commit('currentSession/setPaused', false)
-        break
-      default:
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const _: never = message
+  let socket: WebSocket | null = null
+
+  store.subscribe((mutation: { type: string; payload: any }) => {
+    if (mutation.type === 'currentSession/setSession') {
+      if (mutation.payload) {
+        socket = new WebSocket(SOCKET_URL)
+        socket.onmessage = (e: MessageEvent) => {
+          console.log(e.data)
+          const message = JSON.parse(e.data) as SocketMessage
+          // TODO: 残りケースの実装 cf) https://github.com/camphor-/here-songs-server/blob/master/docs/API.md#get-apiv2ws
+          switch (message.type) {
+            case 'ADDTRACK':
+              store.commit('currentSession/addTrack', message.track)
+              break
+            case 'NEXTTRACK':
+              store.commit('currentSession/nextTrack', message.head)
+              break
+            case 'PLAY':
+              store.commit('currentSession/setPaused', false)
+              break
+            case 'PAUSE':
+              store.commit('currentSession/setPaused', true)
+              break
+            case 'RESUME':
+              store.commit('currentSession/setPaused', false)
+              break
+            case 'INTERRUPT':
+              break
+            case 'PROGRESS':
+              break
+            default:
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const _: never = message
+          }
+        }
+      }
     }
-  }
+  })
 }
 export default WebSocketPlugin


### PR DESCRIPTION
## WHAT

- WebSocket APIをv2向けの実装にした
- とりあえずcurrentSessionにsessinoがセットされるまでは接続しにいかないようにした

## WHY

v1向けのものに繋いでしまうと、全体セッション `theSession` に繋がってしまう