### PR TITLE
再生中の曲情報の文字がはみ出る不具合を修正

### DIFF
--- a/components/molecules/PlayingTrack.vue
+++ b/components/molecules/PlayingTrack.vue
@@ -55,6 +55,9 @@ export default class extends Vue {
     }
     .track-info {
       flex-grow: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }


### PR DESCRIPTION
fix #105 

![image](https://user-images.githubusercontent.com/31735614/71012057-d7736700-2131-11ea-95bb-2833e7814e69.png)
