### PR TITLE
再生と一時停止ボタンをちゃんと押せるようにする

### DIFF
--- a/store/currentSession.ts
+++ b/store/currentSession.ts
@@ -47,8 +47,7 @@ export const getters = {
   playable(state: State): boolean {
     if (state.id === null) return false
     if (!state.delegate) return false
-    if (!state.playback.paused) return true
-    return state.tracks.length - (state.playback.head + 1) > 0
+    return state.tracks.length - (state.playback.head + 1) >= 0
   }
 }
 


### PR DESCRIPTION
## Why
現状では一時停止ボタンを押すと、再生ボタンが表示されなくなってしまう