### PR TITLE
プログレスバーがスムーズに進むようにする

### DIFF
--- a/components/atoms/Seekbar.vue
+++ b/components/atoms/Seekbar.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="seekbar">
-    <span class="progress">{{ progress | timeFormat }}</span>
+    <span class="progress">{{ estimateProgress | timeFormat }}</span>
     <v-progress-linear class="progress-bar" :value="progressPercent" />
     <span class="length">{{ length | timeFormat }}</span>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 
 @Component({
   name: 'Seekbar',
@@ -31,6 +31,14 @@ export default class extends Vue {
   @Prop({ required: true }) readonly length!: number
   @Prop({ required: true }) readonly progress!: number
   @Prop({ required: true }) readonly remaining!: number
+
+  progressTimer: number | null = null
+  estimateProgress = 0
+
+  @Watch('progress')
+  onProgressChanged(val: number) {
+    this.estimateProgress = val
+  }
 }
 </script>
 

--- a/components/atoms/Seekbar.vue
+++ b/components/atoms/Seekbar.vue
@@ -15,7 +15,7 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
   computed: {
     progressPercent() {
       if (this.length === 0) return 0
-      return (this.progress / this.length) * 100
+      return (this.estimateProgress / this.length) * 100
     }
   },
   filters: {
@@ -38,6 +38,19 @@ export default class extends Vue {
   @Watch('progress')
   onProgressChanged(val: number) {
     this.estimateProgress = val
+    this.setProgressTimer()
+  }
+
+  destroyed() {
+    if (this.progressTimer) clearInterval(this.progressTimer)
+  }
+
+  setProgressTimer() {
+    if (this.progressTimer) clearInterval(this.progressTimer)
+    this.progressTimer = window.setInterval(
+      () => (this.estimateProgress += 1000),
+      1000
+    )
   }
 }
 </script>

--- a/components/organisms/SlideMenu.vue
+++ b/components/organisms/SlideMenu.vue
@@ -46,7 +46,7 @@
 
 <script lang="ts">
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
-import { mapState } from 'vuex'
+import { mapMutations, mapState } from 'vuex'
 import ConfirmTerminateSessionDialog from '@/components/molecules/ConfirmTerminateSessionDialog.vue'
 import ApiV2 from '@/api/v2'
 import Snackbar from '@/components/molecules/Snackbar.vue'
@@ -55,11 +55,16 @@ import Snackbar from '@/components/molecules/Snackbar.vue'
   components: { ConfirmTerminateSessionDialog, Snackbar },
   computed: {
     ...mapState('currentSession', ['id'])
+  },
+  methods: {
+    ...mapMutations('currentSession', ['clearSession'])
   }
 })
 export default class extends Vue {
-  private isOpenConfirmTerminateSessionDialog = false
   private id: string | null
+  private clearSession!: () => void
+
+  private isOpenConfirmTerminateSessionDialog = false
   private showSnackbar = false
   private snackbarText = ''
 
@@ -78,6 +83,7 @@ export default class extends Vue {
     try {
       await ApiV2.sessions.current.controlPlayback({ state: 'STOP' })
       this.$router.push('/')
+      this.clearSession()
     } catch (e) {
       console.error(e)
       // TODO: エラー処理
@@ -90,6 +96,7 @@ export default class extends Vue {
         await ApiV2.sessions.leaveSession(this.id)
         this.showSnackbar = true
         this.$router.push({ path: '/' })
+        this.clearSession()
         this.snackbarText = 'セッションから退出しました。'
       } catch (e) {
         if (e.statusCode === 400) {

--- a/store/currentSession.ts
+++ b/store/currentSession.ts
@@ -89,7 +89,6 @@ export const mutations = {
   },
   setPlayback: (state: State, playback: Playback) => {
     if (!state.id) return
-    // 引数をそのまま突っ込むと、INTERUPTで入ってきたtrackがnullになってしまう
     state.playback = playback
   }
 }

--- a/store/plugin/WebSocketPlugin.ts
+++ b/store/plugin/WebSocketPlugin.ts
@@ -7,6 +7,9 @@ const WebSocketPlugin = (store: any) => {
   let socket: WebSocket | null = null
 
   store.subscribe((mutation: { type: string; payload: any }) => {
+    if (mutation.type === 'currentSession/clearSession') {
+      if (socket) socket.close()
+    }
     if (mutation.type === 'currentSession/setSession') {
       if (mutation.payload) {
         if (socket) socket.close()


### PR DESCRIPTION
## WHAT

プログレスバーが5秒おきのサーバーからの送信以外にも、1秒ずつ進むようにしました！
表示上で解決したかった問題なので、SeekBarコンポーネントに処理を書きました。

## WHY

見栄え

## スクリーンショット

![7rkkv-wd3mk](https://user-images.githubusercontent.com/31735614/72679497-0dba5280-3af3-11ea-8886-00ff1d43500b.gif)
