### PR TITLE
ログイン時のリダイレクトURLを明示的に指定する

### DIFF
--- a/api/v3/auth.ts
+++ b/api/v3/auth.ts
@@ -1,5 +1,8 @@
 import { baseURL } from '@/api/v3/index'
 
-export const getLoginUrl = () => {
+export const getLoginUrl = (redirectUrl: string | null) => {
+  if (redirectUrl) {
+    return `${baseURL}/login?redirect_url=${redirectUrl}`
+  }
   return `${baseURL}/login`
 }

--- a/components/organisms/LoginButton.vue
+++ b/components/organisms/LoginButton.vue
@@ -14,7 +14,7 @@ import { getLoginUrl } from '@/api/v3/auth'
 })
 export default class extends Vue {
   login() {
-    location.href = getLoginUrl()
+    location.href = getLoginUrl(location.origin)
   }
 }
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -201,8 +201,7 @@ const nuxtConfig: NuxtConfiguration = {
   env: {
     BASE_URL: process.env.BASE_URL || 'http://relaym.local:8080',
     BASE_WEBSOCKET_URL:
-      process.env.BASE_WEBSOCKET_URL || 'ws://relaym.local:8080/api/v3',
-    SPOTIFY_CLIENT_ID: '49a1da87167748c6bbe344a15817f184'
+      process.env.BASE_WEBSOCKET_URL || 'ws://relaym.local:8080/api/v3'
   }
 }
 


### PR DESCRIPTION
## Why
デプロイプレビュー時に元のURLに戻ってこれなくなるため

## Memo
ローカル開発時は `relaym.local:3000` を使ってね