### PR TITLE
全てのAPIでエラーが発生したらエラーのsnackbarを表示するようにする

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -88,7 +88,7 @@ export default class Index extends Vue {
       })
       this.$router.push({ path: `/sessions/${newSession.id}` })
     } catch (e) {
-      console.log(e)
+      console.error(e)
       this.showServerErrorSnackbar()
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,7 +39,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
-import { mapState, mapGetters } from 'vuex'
+import { mapState, mapGetters, mapActions } from 'vuex'
 import ToppageLogo from '@/components/molecules/ToppageLogo.vue'
 import NewSessionDialog from '@/components/organisms/NewSessionDialog.vue'
 import LoginButton from '@/components/organisms/LoginButton.vue'
@@ -58,12 +58,17 @@ import { User } from '@/api/v3/types'
   computed: {
     ...mapState('user', ['me']),
     ...mapGetters('user', ['isLoggedIn'])
+  },
+  methods: {
+    ...mapActions('snackbar', ['showServerErrorSnackbar'])
   }
 })
 export default class Index extends Vue {
   private readonly me!: User | null
 
   private isLoggedIn!: () => boolean
+
+  private showServerErrorSnackbar!: () => void
 
   private isBanDialogOpen: boolean = false
   private isNewSessionDialogOpen: boolean = false
@@ -77,10 +82,15 @@ export default class Index extends Vue {
   }
 
   async createSession(payload: { name: string }) {
-    const newSession = await createSession({
-      name: payload.name
-    })
-    this.$router.push({ path: `/sessions/${newSession.id}` })
+    try {
+      const newSession = await createSession({
+        name: payload.name
+      })
+      this.$router.push({ path: `/sessions/${newSession.id}` })
+    } catch (e) {
+      console.log(e)
+      this.showServerErrorSnackbar()
+    }
   }
 }
 </script>

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -8,7 +8,6 @@ import {
 } from '@/api/v3/session'
 
 import { createWebSocket } from '@/api/v3/websocket'
-import { MessageType } from '@/store/snackbar'
 
 interface State {
   sessionId: string | null
@@ -88,14 +87,7 @@ export const actions: ActionTree<State, {}> = {
       await dispatch('setProgressTimer')
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   async fetchAvailableDevices({ state, dispatch, commit }) {
@@ -105,14 +97,7 @@ export const actions: ActionTree<State, {}> = {
       commit('setAvailableDevices', res)
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   async setDevice({ state, dispatch }, deviceId: string) {
@@ -122,14 +107,7 @@ export const actions: ActionTree<State, {}> = {
       dispatch('fetchSession')
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   connectWebSocket({ state, commit, dispatch }) {
@@ -144,14 +122,7 @@ export const actions: ActionTree<State, {}> = {
       commit('setWebSocket', socket)
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   disconnectWebSocket({ state }) {
@@ -175,14 +146,7 @@ export const actions: ActionTree<State, {}> = {
       await controlPlayback(state.sessionId, req)
     } catch (e) {
       console.log(e)
-      await dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      await dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   setProgressTimer: async ({ state, commit, dispatch }) => {

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -86,7 +86,7 @@ export const actions: ActionTree<State, {}> = {
       commit('setSession', session)
       await dispatch('setProgressTimer')
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
@@ -96,7 +96,7 @@ export const actions: ActionTree<State, {}> = {
       const res = await getDevices(state.sessionId)
       commit('setAvailableDevices', res)
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
@@ -106,7 +106,7 @@ export const actions: ActionTree<State, {}> = {
       await setDevice(state.session.id, { deviceId })
       dispatch('fetchSession')
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
@@ -121,7 +121,7 @@ export const actions: ActionTree<State, {}> = {
       socket.onclose = () => commit('setWebSocket', null)
       commit('setWebSocket', socket)
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
@@ -145,7 +145,7 @@ export const actions: ActionTree<State, {}> = {
     try {
       await controlPlayback(state.sessionId, req)
     } catch (e) {
-      console.log(e)
+      console.error(e)
       await dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -8,6 +8,7 @@ import {
 } from '@/api/v3/session'
 
 import { createWebSocket } from '@/api/v3/websocket'
+import { MessageType } from '@/store/snackbar'
 
 interface State {
   sessionId: string | null
@@ -81,29 +82,77 @@ export const actions: ActionTree<State, {}> = {
   },
   async fetchSession({ state, commit, dispatch }) {
     if (!state.sessionId) return
-    const session = await getSession(state.sessionId)
-    commit('setSession', session)
-    await dispatch('setProgressTimer')
+    try {
+      const session = await getSession(state.sessionId)
+      commit('setSession', session)
+      await dispatch('setProgressTimer')
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
-  async fetchAvailableDevices({ state, commit }) {
+  async fetchAvailableDevices({ state, dispatch, commit }) {
     if (!state.sessionId) return
-    const res = await getDevices(state.sessionId)
-    commit('setAvailableDevices', res)
+    try {
+      const res = await getDevices(state.sessionId)
+      commit('setAvailableDevices', res)
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
   async setDevice({ state, dispatch }, deviceId: string) {
     if (!state.session) return
-    await setDevice(state.session.id, { deviceId })
-    dispatch('fetchSession')
+    try {
+      await setDevice(state.session.id, { deviceId })
+      dispatch('fetchSession')
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
   connectWebSocket({ state, commit, dispatch }) {
     if (!state.sessionId) return
     if (state.webSocket) dispatch('disconnectWebSocket')
 
-    const socket = createWebSocket(state.sessionId)
-    socket.onmessage = (ev) =>
-      dispatch('handleWebSocketMessage', JSON.parse(ev.data))
-    socket.onclose = () => commit('setWebSocket', null)
-    commit('setWebSocket', socket)
+    try {
+      const socket = createWebSocket(state.sessionId)
+      socket.onmessage = (ev) =>
+        dispatch('handleWebSocketMessage', JSON.parse(ev.data))
+      socket.onclose = () => commit('setWebSocket', null)
+      commit('setWebSocket', socket)
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
   disconnectWebSocket({ state }) {
     if (!state.webSocket) return
@@ -117,9 +166,24 @@ export const actions: ActionTree<State, {}> = {
         commit('setIsInterruptDetectedDialogOpen', true)
     }
   },
-  controlPlayback: ({ state }, req: { state: 'PLAY' | 'PAUSE' }) => {
+  controlPlayback: async (
+    { state, dispatch },
+    req: { state: 'PLAY' | 'PAUSE' }
+  ) => {
     if (!state.sessionId) return
-    controlPlayback(state.sessionId, req)
+    try {
+      await controlPlayback(state.sessionId, req)
+    } catch (e) {
+      console.log(e)
+      await dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
   setProgressTimer: async ({ state, commit, dispatch }) => {
     if (state.progressTimer) await dispatch('clearProgressTimer')

--- a/store/pages/sessions/search.ts
+++ b/store/pages/sessions/search.ts
@@ -1,6 +1,7 @@
 import { MutationTree, ActionTree } from 'vuex'
 import { enqueue, search } from '@/api/v3/session'
 import { Track } from '@/api/v3/types'
+import { MessageType } from '@/store/snackbar'
 
 interface State {
   sessionId: string | null
@@ -24,12 +25,36 @@ export const actions: ActionTree<State, {}> = {
   setSessionId({ commit }, sessionId: string) {
     commit('setSessionId', sessionId)
   },
-  async fetchSearchResult({ state, commit }, q) {
+  async fetchSearchResult({ state, dispatch, commit }, q) {
     if (!state.sessionId) return
-    commit('setResult', await search(state.sessionId, { q }))
+    try {
+      commit('setResult', await search(state.sessionId, { q }))
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   },
-  async enqueueTrack({ state }, uri: string) {
+  async enqueueTrack({ state, dispatch }, uri: string) {
     if (!state.sessionId) return
-    await enqueue(state.sessionId, { uri })
+    try {
+      await enqueue(state.sessionId, { uri })
+    } catch (e) {
+      console.log(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
+    }
   }
 }

--- a/store/pages/sessions/search.ts
+++ b/store/pages/sessions/search.ts
@@ -1,7 +1,6 @@
 import { MutationTree, ActionTree } from 'vuex'
 import { enqueue, search } from '@/api/v3/session'
 import { Track } from '@/api/v3/types'
-import { MessageType } from '@/store/snackbar'
 
 interface State {
   sessionId: string | null
@@ -31,14 +30,7 @@ export const actions: ActionTree<State, {}> = {
       commit('setResult', await search(state.sessionId, { q }))
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
   async enqueueTrack({ state, dispatch }, uri: string) {
@@ -47,14 +39,7 @@ export const actions: ActionTree<State, {}> = {
       await enqueue(state.sessionId, { uri })
     } catch (e) {
       console.log(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   }
 }

--- a/store/pages/sessions/search.ts
+++ b/store/pages/sessions/search.ts
@@ -29,7 +29,7 @@ export const actions: ActionTree<State, {}> = {
     try {
       commit('setResult', await search(state.sessionId, { q }))
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   },
@@ -38,7 +38,7 @@ export const actions: ActionTree<State, {}> = {
     try {
       await enqueue(state.sessionId, { uri })
     } catch (e) {
-      console.log(e)
+      console.error(e)
       dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
     }
   }

--- a/store/snackbar.ts
+++ b/store/snackbar.ts
@@ -50,6 +50,12 @@ export const actions = {
     }
     commit('open')
   },
+  showServerErrorSnackbar({ dispatch }) {
+    dispatch('showSnackbar', {
+      message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+      messageType: MessageType.error
+    })
+  },
   closeSnackbar({ commit }) {
     commit('close')
   },

--- a/store/snackbar.ts
+++ b/store/snackbar.ts
@@ -52,7 +52,7 @@ export const actions = {
   },
   showServerErrorSnackbar({ dispatch }) {
     dispatch('showSnackbar', {
-      message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+      message: 'エラーが発生しました。時間をおいて再度お試しください。',
       messageType: MessageType.error
     })
   },

--- a/store/user.ts
+++ b/store/user.ts
@@ -1,5 +1,6 @@
 import { getMyUserInfo } from '@/api/v3/user'
 import { User } from '@/api/v3/types'
+import { MessageType } from '@/store/snackbar'
 
 interface State {
   me: User | null
@@ -21,12 +22,20 @@ export const mutations = {
 }
 
 export const actions = {
-  async fetchMyUserInfo({ commit }) {
+  async fetchMyUserInfo({ dispatch, commit }) {
     try {
       const res = await getMyUserInfo()
       commit('setMyUserInfo', res)
     } catch (e) {
       console.error(e)
+      dispatch(
+        'snackbar/showSnackbar',
+        {
+          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
+          messageType: MessageType.error
+        },
+        { root: true }
+      )
       commit('setMyUserInfo', null)
     }
   }

--- a/store/user.ts
+++ b/store/user.ts
@@ -1,6 +1,5 @@
 import { getMyUserInfo } from '@/api/v3/user'
 import { User } from '@/api/v3/types'
-import { MessageType } from '@/store/snackbar'
 
 interface State {
   me: User | null
@@ -28,14 +27,7 @@ export const actions = {
       commit('setMyUserInfo', res)
     } catch (e) {
       console.error(e)
-      dispatch(
-        'snackbar/showSnackbar',
-        {
-          message: 'エラーが 発生しました。時間をおいて再度お試しください。',
-          messageType: MessageType.error
-        },
-        { root: true }
-      )
+      dispatch('snackbar/showServerErrorSnackbar', null, { root: true })
       commit('setMyUserInfo', null)
     }
   }


### PR DESCRIPTION
## Related Issue
#209 

## What
- 一旦全てのAPIで、エラーだったらSnackbarを表示するようにしました
  - これでデバイスでデバッグ時にAPIがエラってるのかどうかがわかりやすくなります
- 4xx系のエラーのハンドリングは次のPRでやります

<img width="369" alt="スクリーンショット 2020-07-03 22 42 50" src="https://user-images.githubusercontent.com/30015728/86474907-b6492f80-bd7e-11ea-9140-a5754a1eded0.png">
