### PR TITLE
Web Share APIのキャンセル時のエラー扱いを修正

### DIFF
--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -6,7 +6,7 @@
       <v-btn flat icon color="#00B900" @click="handleClickLineShare">
         <v-icon>fab fa-line</v-icon>
       </v-btn>
-      <v-btn flat icon @click="handleClickWebShare">
+      <v-btn v-if="canShare" flat icon @click="handleClickWebShare">
         <v-icon>fas fa-share-alt</v-icon>
       </v-btn>
       <v-btn depressed @click="handleClickCopy">コピー</v-btn>
@@ -39,6 +39,10 @@ export default class extends Vue {
   get inviteUrl() {
     if (!this.sessionId) return ''
     return `${location.origin}/sessions/${this.sessionId}`
+  }
+
+  get canShare(): boolean {
+    return !!navigator.share
   }
 
   handleClickLineShare() {

--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -58,14 +58,7 @@ export default class extends Vue {
       text: 'Relaymで一緒にセッションを楽しもう！',
       url: this.inviteUrl
     }
-    try {
-      await navigator.share(shareData)
-    } catch (e) {
-      this.showSnackbar({
-        message: 'シェアに失敗しました',
-        messageType: MessageType.error
-      })
-    }
+    await navigator.share(shareData)
   }
 
   handleClickCopy() {


### PR DESCRIPTION
## What

- Web Share APIを使ったシェアボタンを利用可能な環境でのみ出すようにした
  - つまり基本PCでは非表示になる
- シェアキャンセル時のエラーをハンドリングしない

## Why

fix #216 