### PR TITLE
プログレスバーがToolBarの上に透けるのを修正

### DIFF
--- a/components/molecules/SessionToolbar.vue
+++ b/components/molecules/SessionToolbar.vue
@@ -23,7 +23,7 @@ export default class extends Vue {
 
 <style lang="scss" scoped>
 .session-toolbar {
-  z-index: 1;
+  z-index: 10;
   position: fixed;
   width: 100vw;
   display: flex;


### PR DESCRIPTION
## What

- SessionToolbarのz-indexを大きくした

## Why

fix #279 

v-progress-linearが中で `z-index: 1` をしていた