### PR TITLE
セッション作成時のallowToControlByOthersを実装

### DIFF
--- a/api/v3/session.ts
+++ b/api/v3/session.ts
@@ -2,12 +2,16 @@ import { Device, Session, Track } from '@/api/v3/types'
 import { instance } from '@/api/v3/index'
 
 export const createSession = async (req: CreateSessionRequest) => {
-  const res = await instance.post<Session>('/sessions', req)
+  const res = await instance.post<Session>('/sessions', {
+    name: req.name,
+    allow_to_control_by_others: req.allowToControlByOthers
+  })
   return res.data
 }
 
 interface CreateSessionRequest {
   name: string
+  allowToControlByOthers: boolean
 }
 
 export const getSession = async (id: string) => {

--- a/api/v3/types.ts
+++ b/api/v3/types.ts
@@ -6,6 +6,7 @@ export interface Session {
   creator: Creator
   playback: Playback
   queue: Queue
+  allow_to_control_by_others: boolean
 }
 
 export interface Creator {

--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -11,7 +11,11 @@
       </v-btn>
       <v-btn depressed @click="handleClickCopy">コピー</v-btn>
     </v-layout>
-    <v-layout align-start class="attention accent--text">
+    <v-layout
+      v-if="isShowShareWarning"
+      align-start
+      class="attention accent--text"
+    >
       <v-icon color="accent">warning</v-icon>
       <span>このリンクは不特定多数の人に共有しないでください</span>
     </v-layout>
@@ -34,6 +38,7 @@ import { MessageType, SnackbarPayload } from '@/store/snackbar'
 })
 export default class extends Vue {
   @Prop({ required: true }) readonly sessionId!: string | null
+  @Prop({ default: true }) readonly isShowShareWarning!: boolean
   private showSnackbar!: (payload: SnackbarPayload) => void
 
   get inviteUrl() {

--- a/components/organisms/BottomController.vue
+++ b/components/organisms/BottomController.vue
@@ -5,7 +5,7 @@
         <v-btn icon large @click="openDeviceSelectDialog">
           <v-icon>devices</v-icon>
         </v-btn>
-        <v-btn icon @click="togglePlayback">
+        <v-btn icon :disabled="!canControlPlayback" @click="togglePlayback">
           <v-icon v-if="paused" color="accent" x-large class="play-icon">
             play_arrow
           </v-icon>
@@ -23,7 +23,7 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator'
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapState, mapGetters } from 'vuex'
 import { Session } from '@/api/v3/types'
 import { MessageType, SnackbarPayload } from '@/store/snackbar'
 import ActiveDeviceNotFoundDialog from '@/components/organisms/ActiveDeviceNotFoundDialog.vue'
@@ -35,11 +35,13 @@ import ActiveDeviceNotFoundDialog from '@/components/organisms/ActiveDeviceNotFo
     ...mapActions('snackbar', ['showSnackbar'])
   },
   computed: {
-    ...mapState('pages/sessions/detail', ['session'])
+    ...mapState('pages/sessions/detail', ['session']),
+    ...mapGetters('pages/sessions/detail', ['canControlPlayback'])
   }
 })
 export default class extends Vue {
   private readonly session!: Session | null
+  private readonly canControlPlayback!: boolean
   private controlState!: (req: { state: 'PLAY' | 'PAUSE' }) => Promise<void>
   private showController = true
   private showSnackbar!: (payload: SnackbarPayload) => void

--- a/components/organisms/NewSessionDialog.vue
+++ b/components/organisms/NewSessionDialog.vue
@@ -4,6 +4,10 @@
       <v-card-title>New Session</v-card-title>
       <v-card-text>
         <v-text-field v-model="sessionName" label="セッション名" />
+        <v-switch
+          v-model="allowToControlByOthers"
+          label="他の人に再生/一時停止を許可"
+        />
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -30,6 +34,7 @@ export default class extends Vue {
   @Prop({ default: false }) readonly value!: boolean
 
   private sessionName: string = ''
+  private allowToControlByOthers: boolean = false
 
   @Emit()
   input(isOpen: boolean) {
@@ -42,7 +47,10 @@ export default class extends Vue {
 
   @Emit()
   createSession() {
-    return { name: this.sessionName }
+    return {
+      name: this.sessionName,
+      allowToControlByOthers: this.allowToControlByOthers
+    }
   }
 }
 </script>

--- a/components/organisms/NewSessionDialog.vue
+++ b/components/organisms/NewSessionDialog.vue
@@ -8,6 +8,17 @@
           v-model="allowToControlByOthers"
           label="他の人に再生/一時停止を許可"
         />
+
+        <v-layout
+          v-if="allowToControlByOthers"
+          align-start
+          class="attention accent--text"
+        >
+          <v-icon color="accent">warning</v-icon>
+          <span
+            >操作の乗っ取りを防ぐため、<br />リンクを不特定多数に共有しないでください</span
+          >
+        </v-layout>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -55,4 +66,12 @@ export default class extends Vue {
 }
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+.attention {
+  font-size: 0.8rem;
+
+  span {
+    margin-left: 8px;
+  }
+}
+</style>

--- a/components/organisms/NewSessionDialog.vue
+++ b/components/organisms/NewSessionDialog.vue
@@ -6,7 +6,7 @@
         <v-text-field v-model="sessionName" label="セッション名" />
         <v-switch
           v-model="allowToControlByOthers"
-          label="他の人に再生/一時停止を許可"
+          label="共有相手に再生/一時停止を許可"
         />
 
         <v-layout

--- a/components/organisms/SlideMenu.vue
+++ b/components/organisms/SlideMenu.vue
@@ -13,7 +13,11 @@
             <v-list-tile-title>Home</v-list-tile-title>
           </v-list-tile-content>
         </v-list-tile>
-        <invite-link-box class="invite-link-box" :session-id="sessionId" />
+        <invite-link-box
+          class="invite-link-box"
+          :session-id="sessionId"
+          :is-show-share-warning="allowToControlByOthers"
+        />
       </v-list>
     </v-navigation-drawer>
   </div>
@@ -23,20 +27,27 @@
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
 import { mapState } from 'vuex'
 import InviteLinkBox from '@/components/molecules/InviteLinkBox.vue'
+import { Session } from '@/api/v3/types'
 
 @Component({
   components: { InviteLinkBox },
   computed: {
-    ...mapState('pages/sessions/detail', ['sessionId'])
+    ...mapState('pages/sessions/detail', ['sessionId', 'session'])
   }
 })
 export default class extends Vue {
   @Prop({ default: false }) readonly value!: boolean
   private readonly sessionid!: string | null
+  private readonly session!: Session | null
 
   @Emit()
   input(isOpen: boolean) {
     return isOpen
+  }
+
+  get allowToControlByOthers(): boolean {
+    // eslint-disable-next-line camelcase
+    return this.session?.allow_to_control_by_others ?? true
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -78,11 +78,12 @@ export default class Index extends Vue {
     this.isNewSessionDialogOpen = true
   }
 
-  async createSession(payload: { name: string }) {
+  async createSession(payload: {
+    name: string
+    allowToControlByOthers: boolean
+  }) {
     try {
-      const newSession = await createSession({
-        name: payload.name
-      })
+      const newSession = await createSession(payload)
       this.$router.push({ path: `/sessions/${newSession.id}` })
     } catch (e) {
       if (e.response?.status === 400) {

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -38,6 +38,17 @@ export const getters = {
   },
   playableDevices(state: State): Device[] {
     return state.devices.filter((d) => !d.is_restricted)
+  },
+  isMyOwnSession(state: State, _getters, rootState): boolean {
+    if (!state.session) return false
+    return state.session.creator.id === rootState.user.me?.id
+  },
+  canControlPlayback(state: State, getters): boolean {
+    return (
+      getters.isMyOwnSession ||
+      // eslint-disable-next-line camelcase
+      (state.session?.allow_to_control_by_others ?? false)
+    )
   }
 }
 


### PR DESCRIPTION
## What

- セッション作成時に再生/一時停止の操作を許可するか選べるようにしました
  - デフォルトはオフ
  - オンにすると注意書きが表示されます
- サイドメニューで再生/一時停止の操作が許可されていないときは、注意書きを表示しないようにしました

## Why

https://github.com/camphor-/relaym-server/pull/151

## スクリーンショット

![image](https://user-images.githubusercontent.com/31735614/88769582-8d6a5d80-d1b7-11ea-9589-896cc2b9b1a5.png)
