### PR TITLE
複数人アーティストの表示に対応する

### DIFF
--- a/components/molecules/SearchResultList.vue
+++ b/components/molecules/SearchResultList.vue
@@ -14,7 +14,7 @@
         <v-list-tile-content>
           <v-list-tile-title>{{ item.name }}</v-list-tile-title>
           <v-list-tile-sub-title>
-            {{ item.artists.map((artist) => artist.name).join('、') }} -
+            {{ item.artists.map((artist) => artist.name).join(', ') }} -
             {{ item.album.name }}
           </v-list-tile-sub-title>
         </v-list-tile-content>

--- a/components/molecules/SearchResultList.vue
+++ b/components/molecules/SearchResultList.vue
@@ -14,7 +14,8 @@
         <v-list-tile-content>
           <v-list-tile-title>{{ item.name }}</v-list-tile-title>
           <v-list-tile-sub-title>
-            {{ item.album.name }} - {{ item.artists[0].name }}
+            {{ item.artists.map((artist) => artist.name).join('、') }} -
+            {{ item.album.name }}
           </v-list-tile-sub-title>
         </v-list-tile-content>
         <v-list-tile-action>

--- a/components/molecules/TrackListItem.vue
+++ b/components/molecules/TrackListItem.vue
@@ -6,7 +6,7 @@
     <v-list-tile-content>
       <v-list-tile-title>{{ track.name }}</v-list-tile-title>
       <v-list-tile-sub-title>
-        {{ track.artists.map((artist) => artist.name).join('、') }} -
+        {{ track.artists.map((artist) => artist.name).join(', ') }} -
         {{ track.album.name }}
       </v-list-tile-sub-title>
     </v-list-tile-content>

--- a/components/molecules/TrackListItem.vue
+++ b/components/molecules/TrackListItem.vue
@@ -5,8 +5,9 @@
     </v-list-tile-avatar>
     <v-list-tile-content>
       <v-list-tile-title>{{ track.name }}</v-list-tile-title>
-      <v-list-tile-sub-title
-        >{{ track.album.name }} - {{ track.artists[0].name }}
+      <v-list-tile-sub-title>
+        {{ track.artists.map((artist) => artist.name).join('、') }} -
+        {{ track.album.name }}
       </v-list-tile-sub-title>
     </v-list-tile-content>
   </v-list-tile>


### PR DESCRIPTION
close #233 

## What
- 複数人アーティストの表示に対応する
- アーティストが長くなるので、アルバム名より先に表示する

<img width="371" alt="スクリーンショット 2020-07-29 19 36 05" src="https://user-images.githubusercontent.com/30015728/88790467-2e1a4680-d1d3-11ea-90a1-b12cb62c44b9.png">
<img width="371" alt="スクリーンショット 2020-07-29 19 38 01" src="https://user-images.githubusercontent.com/30015728/88790473-31adcd80-d1d3-11ea-921d-64775441aabb.png">
