### PR TITLE
APIコール数の削減のために、Websocketの再接続のみfetchSessionを行うようにする

### DIFF
--- a/pages/sessions/_id/index.vue
+++ b/pages/sessions/_id/index.vue
@@ -81,7 +81,7 @@ import SessionArchivedHeader from '@/components/atoms/SessionArchivedHeader.vue'
   }
 })
 export default class extends Vue {
-  private setSessionId!: (id: string) => Promise<void>
+  private setSessionId!: (id: string) => void
   private fetchSession!: () => Promise<void>
   private setDevice!: (deviceId: string) => void
   private connectWebSocket!: () => void
@@ -99,9 +99,9 @@ export default class extends Vue {
   private isOpeningSpotify: boolean = false
 
   @Watch('$route.params.id', { immediate: true })
-  async onPathIdChanged() {
+  onPathIdChanged() {
     try {
-      await this.setSessionId(this.$route.params.id)
+      this.setSessionId(this.$route.params.id)
     } catch (e) {
       this.$router.push({ name: 'error' })
     }

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -169,7 +169,6 @@ export const actions: ActionTree<State, {}> = {
       const socket = createWebSocket(state.sessionId)
       socket.onopen = () => {
         commit('setWebSocketRetryInterval', DEFAULT_WEBSOCKET_RETRY_INTERVAL)
-        dispatch('fetchSession')
       }
       socket.onmessage = (ev) =>
         dispatch('handleWebSocketMessage', JSON.parse(ev.data))
@@ -214,6 +213,7 @@ export const actions: ActionTree<State, {}> = {
       { root: true }
     )
     await dispatch('connectWebSocket')
+    await dispatch('fetchSession')
   },
   handleWebSocketMessage: ({ dispatch, commit }, message: SocketMessage) => {
     console.log(message)

--- a/store/pages/sessions/detail.ts
+++ b/store/pages/sessions/detail.ts
@@ -100,9 +100,8 @@ export const mutations: MutationTree<State> = {
 }
 
 export const actions: ActionTree<State, {}> = {
-  async setSessionId({ commit, dispatch }, id: string) {
+  setSessionId({ commit }, id: string) {
     commit('setSessionId', id)
-    await dispatch('fetchSession')
   },
   async fetchSession({ state, commit, dispatch }) {
     if (!state.sessionId) return
@@ -168,6 +167,7 @@ export const actions: ActionTree<State, {}> = {
     try {
       const socket = createWebSocket(state.sessionId)
       socket.onopen = () => {
+        dispatch('fetchSession')
         commit('setWebSocketRetryInterval', DEFAULT_WEBSOCKET_RETRY_INTERVAL)
       }
       socket.onmessage = (ev) =>
@@ -213,7 +213,6 @@ export const actions: ActionTree<State, {}> = {
       { root: true }
     )
     await dispatch('connectWebSocket')
-    await dispatch('fetchSession')
   },
   handleWebSocketMessage: ({ dispatch, commit }, message: SocketMessage) => {
     console.log(message)


### PR DESCRIPTION
## Why

セッション詳細画面を開くときに2回APIを叩いていた

connect時はpageコンポーネントが呼ぶ `setSessionId` 経由で `fetchSession` が叩かれるので問題ない