### PR TITLE
アクセシビリティ対応を頑張った

### DIFF
--- a/components/atoms/QrCode.vue
+++ b/components/atoms/QrCode.vue
@@ -1,5 +1,5 @@
 <template>
-  <img class="qrcode" :src="qrSvg" />
+  <img class="qrcode" alt="QRコード" :src="qrSvg" />
 </template>
 
 <script lang="ts">

--- a/components/atoms/ServiceDescriptionHeader.vue
+++ b/components/atoms/ServiceDescriptionHeader.vue
@@ -2,7 +2,7 @@
   <div class="service-description-header">
     <h2><slot /></h2>
     <span class="dots" />
-    <img class="note-icon" src="../../assets/images/note_icon.svg" />
+    <img class="note-icon" src="../../assets/images/note_icon.svg" alt="" />
   </div>
 </template>
 

--- a/components/atoms/ServiceFeature.vue
+++ b/components/atoms/ServiceFeature.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="service-feature">
     <div class="feature-icon">
-      <img :src="iconSrc" />
+      <img :src="iconSrc" alt="" />
     </div>
     <h3 class="feature-header"><slot name="header" /></h3>
     <div class="feature-body"><slot name="body" /></div>

--- a/components/atoms/ShareButtons.vue
+++ b/components/atoms/ShareButtons.vue
@@ -7,6 +7,7 @@
       icon
       color="#1da1f2"
       :href="twitterUrl"
+      aria-label="Twitterでシェア"
     >
       <v-icon>fab fa-twitter</v-icon>
     </v-btn>
@@ -17,10 +18,19 @@
       icon
       color="#1877f2"
       :href="facebookUrl"
+      aria-label="Facebookでシェア"
     >
       <v-icon>fab fa-facebook-f</v-icon>
     </v-btn>
-    <v-btn class="fa-icon-button" fab dark icon color="#00B900" :href="lineUrl">
+    <v-btn
+      class="fa-icon-button"
+      fab
+      dark
+      icon
+      color="#00B900"
+      :href="lineUrl"
+      aria-label="LINEでシェア"
+    >
       <v-icon>fab fa-line</v-icon>
     </v-btn>
   </div>

--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -8,14 +8,27 @@
         flat
         icon
         color="#1da1f2"
+        aria-label="Twitterで招待"
         @click="handleClickTwitterShare"
       >
         <v-icon>fab fa-twitter</v-icon>
       </v-btn>
-      <v-btn flat icon color="#00B900" @click="handleClickLineShare">
+      <v-btn
+        flat
+        icon
+        color="#00B900"
+        aria-label="LINEで招待"
+        @click="handleClickLineShare"
+      >
         <v-icon>fab fa-line</v-icon>
       </v-btn>
-      <v-btn v-if="canShare" flat icon @click="handleClickWebShare">
+      <v-btn
+        v-if="canShare"
+        flat
+        icon
+        aria-label="URLを共有"
+        @click="handleClickWebShare"
+      >
         <v-icon>fas fa-share-alt</v-icon>
       </v-btn>
       <v-btn depressed @click="handleClickCopy">コピー</v-btn>

--- a/components/molecules/PlayingTrack.vue
+++ b/components/molecules/PlayingTrack.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="playing">
     <div class="track-container">
-      <img :src="playingTrack.album.images[1].url" />
+      <img :src="playingTrack.album.images[1].url" alt="カバー画像" />
       <div class="track-info">
         <v-list-tile-title>{{ playingTrack.name }}</v-list-tile-title>
         <v-list-tile-sub-title

--- a/components/molecules/SearchResultList.vue
+++ b/components/molecules/SearchResultList.vue
@@ -19,7 +19,7 @@
           </v-list-tile-sub-title>
         </v-list-tile-content>
         <v-list-tile-action>
-          <v-btn icon large @click="clickItem(item)">
+          <v-btn icon large aria-label="曲を追加" @click="clickItem(item)">
             <v-icon color="primary" size="28">add_circle</v-icon>
           </v-btn>
         </v-list-tile-action>

--- a/components/molecules/SessionToolbar.vue
+++ b/components/molecules/SessionToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="session-toolbar">
-    <v-btn icon @click="openSliderMenu">
+    <v-btn icon aria-label="サイドメニュー" @click="openSliderMenu">
       <v-icon color="white">menu</v-icon>
     </v-btn>
     <span class="session-name">{{ sessionName }}</span>

--- a/components/molecules/TrackListItem.vue
+++ b/components/molecules/TrackListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <v-list-tile class="list-item">
     <v-list-tile-avatar tile>
-      <img :src="track.album.images[1].url" />
+      <img :src="track.album.images[1].url" alt="カバー画像" />
     </v-list-tile-avatar>
     <v-list-tile-content>
       <v-list-tile-title>{{ track.name }}</v-list-tile-title>

--- a/components/organisms/BottomController.vue
+++ b/components/organisms/BottomController.vue
@@ -6,11 +6,17 @@
           icon
           large
           :disabled="!hasPermissionToControlPlayback"
+          aria-label="デバイスを指定"
           @click="openDeviceSelectDialog"
         >
           <v-icon>devices</v-icon>
         </v-btn>
-        <v-btn icon :disabled="!canControlState" @click="togglePlayback">
+        <v-btn
+          icon
+          :disabled="!canControlState"
+          :aria-label="paused ? '再生' : '一時停止'"
+          @click="togglePlayback"
+        >
           <v-icon v-if="paused" color="accent" x-large class="play-icon">
             play_arrow
           </v-icon>
@@ -22,6 +28,7 @@
           nuxt
           :to="searchPageUrl"
           :disabled="isSessionArchived"
+          aria-label="曲を追加"
         >
           <v-icon>playlist_add</v-icon>
         </v-btn>

--- a/components/organisms/ServiceDescription.vue
+++ b/components/organisms/ServiceDescription.vue
@@ -70,21 +70,30 @@
           <howto-step-header class="step-header" num="1"
             >セッションに招待する</howto-step-header
           >
-          <img src="~/assets/images/step1.png" />
+          <img
+            src="~/assets/images/step1.png"
+            alt="サイドメニューを開くと、セッションのQRコードやURLを共有することができます。"
+          />
         </div>
 
         <div>
           <howto-step-header class="step-header" num="2"
             >曲をキューに追加する</howto-step-header
           >
-          <img src="~/assets/images/step2.png" />
+          <img
+            src="~/assets/images/step2.png"
+            alt="セッションページ下部の＋ボタンを押すと、検索画面に移ります。曲名やアーティスト名などを入力して、追加したい曲の横にある＋ボタンをタップしましょう。"
+          />
         </div>
 
         <div>
           <howto-step-header class="step-header" num="3"
             >セッションを再生する</howto-step-header
           >
-          <img src="~/assets/images/step3.png" />
+          <img
+            src="~/assets/images/step3.png"
+            alt="セッションページ下部の再生ボタンを押すと、再生が始まります。"
+          />
         </div>
       </div>
     </section>

--- a/components/organisms/SlideMenu.vue
+++ b/components/organisms/SlideMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-navigation-drawer :value="value" fixed temporary @input="input">
-      <img class="text-logo" src="~assets/images/text_logo.svg" />
+      <img class="text-logo" src="~assets/images/text_logo.svg" alt="Relaym" />
       <v-list>
         <v-list-tile to="/" nuxt>
           <v-list-tile-avatar>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,11 @@
       <v-flex>
         <toppage-logo class="logo" />
 
-        <img class="text-logo" src="~assets/images/text_logo.svg" />
+        <img
+          class="text-logo"
+          src="~assets/images/text_logo.svg"
+          alt="Relaym"
+        />
 
         <div class="action-button">
           <!--  TODO: セッション参加者は、URLをもらう説明を書く    -->
@@ -30,7 +34,7 @@
     <img class="wave" src="../assets/images/wave.svg" alt="wave" />
     <div class="scroll-guide">
       <span class="scroll-text">Scroll</span>
-      <img src="../assets/images/scroll_arrow.svg" />
+      <img src="../assets/images/scroll_arrow.svg" alt="" />
     </div>
     <service-description :is-show-login-button="!isLoggedIn" />
 


### PR DESCRIPTION
## What

トップページとセッション詳細ページを主な対象に、Lighthouseで指摘されたアクセシビリティに関する部分を対応しました
行ったのは主に以下の2つ。

- アイコンボタンへの `aria-label` 付与
- 画像への `alt` 付与

## Lighthouse

![image](https://user-images.githubusercontent.com/31735614/89190871-0c5afe00-d5dd-11ea-8bae-fd8e36087963.png)


![image](https://user-images.githubusercontent.com/31735614/89190764-e5043100-d5dc-11ea-877c-53eb60e91c57.png)
