### PR TITLE
一度追加した曲はページ遷移まで追加ボタンを無効にする

### DIFF
--- a/components/molecules/SearchResultList.vue
+++ b/components/molecules/SearchResultList.vue
@@ -19,7 +19,13 @@
           </v-list-tile-sub-title>
         </v-list-tile-content>
         <v-list-tile-action>
-          <v-btn icon large aria-label="曲を追加" @click="clickItem(item)">
+          <v-btn
+            icon
+            large
+            aria-label="曲を追加"
+            :disabled="item.uri in enqueuedTracks"
+            @click="clickItem(item)"
+          >
             <v-icon color="primary" size="28">add_circle</v-icon>
           </v-btn>
         </v-list-tile-action>
@@ -33,12 +39,14 @@
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
 import { Artist, Track } from '@/lib/api/v3/types'
 import { getArtistNames } from '@/lib/artist'
+import { EnqueuedTracks } from '@/store/pages/sessions/search'
 
 @Component({
   components: {}
 })
 export default class extends Vue {
   @Prop({ default: null }) readonly items!: Track[] | null
+  @Prop({ default: {} }) readonly enqueuedTracks!: EnqueuedTracks
 
   @Emit()
   clickItem(track: Track) {

--- a/pages/sessions/_id/search.vue
+++ b/pages/sessions/_id/search.vue
@@ -16,7 +16,11 @@
         ></v-text-field>
       </v-flex>
     </v-layout>
-    <search-result-list :items="result" @click-item="selectTrack" />
+    <search-result-list
+      :items="result"
+      :enqueued-tracks="enqueuedTracks"
+      @click-item="selectTrack"
+    />
   </v-container>
 </template>
 
@@ -33,14 +37,15 @@ const SEARCH_INTERVAL = 1000
 @Component({
   components: { SearchResultList, Snackbar },
   computed: {
-    ...mapState('pages/sessions/search', ['result']),
+    ...mapState('pages/sessions/search', ['result', 'enqueuedTracks']),
     ...mapGetters('pages/sessions/detail', ['sessionName'])
   },
   methods: {
     ...mapActions('pages/sessions/search', [
       'setSessionId',
       'fetchSearchResult',
-      'enqueueTrack'
+      'enqueueTrack',
+      'clearEnqueuedTracks'
     ]),
     ...mapActions('snackbar', ['showSnackbar'])
   }
@@ -49,6 +54,7 @@ export default class Search extends Vue {
   private setSessionId!: (payload: string) => void
   private fetchSearchResult!: (payload: string) => void
   private enqueueTrack!: (payload: string) => void
+  private clearEnqueuedTracks!: () => void
   private q: string = ''
   private lastSearchTime = Date.now()
   private showSnackbar!: (payload: SnackbarPayload) => void
@@ -100,6 +106,7 @@ export default class Search extends Vue {
     if (typeof this.searchTimeoutId === 'number') {
       clearTimeout(this.searchTimeoutId)
     }
+    this.clearEnqueuedTracks()
   }
 
   head() {

--- a/store/pages/sessions/search.ts
+++ b/store/pages/sessions/search.ts
@@ -4,7 +4,7 @@ import { Track } from '@/lib/api/v3/types'
 import { MessageType } from '@/store/snackbar'
 import { RootState } from '~/store/-type'
 
-export type EnqueuedTracks = { [trackUri in string]: boolean }
+export type EnqueuedTracks = { [trackUri: string]: boolean }
 interface State {
   sessionId: string | null
   result: Track[]
@@ -13,7 +13,7 @@ interface State {
 export const state = (): State => ({
   sessionId: null,
   result: [],
-  enqueuedTracks: { 1: true }
+  enqueuedTracks: {}
 })
 
 export const mutations: MutationTree<State> = {


### PR DESCRIPTION
## What

close #336 

曲検索ページで、一度追加した曲はページを移動するまで追加ボタンを無効にするようにしました

## Why

同じ曲の連続追加などの荒らしを防ぐため