### PR TITLE
Twitterシェア時にハッシュタグをつけるように変更

### DIFF
--- a/components/atoms/ShareButtons.vue
+++ b/components/atoms/ShareButtons.vue
@@ -49,7 +49,8 @@ export default class extends Vue {
   get twitterUrl() {
     return getTwitterUrl(
       'Relaym - Spotifyの楽曲を1つのスピーカーで楽しめるWebアプリ',
-      this.shareUrl
+      this.shareUrl,
+      ['Relaym']
     )
   }
 

--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -79,7 +79,9 @@ export default class extends Vue {
   }
 
   handleClickTwitterShare() {
-    const twitterShareUrl = getTwitterUrl(this.inviteText, this.inviteUrl)
+    const twitterShareUrl = getTwitterUrl(this.inviteText, this.inviteUrl, [
+      'Relaym'
+    ])
     window.open(twitterShareUrl)
   }
 

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,7 +1,11 @@
-export function getTwitterUrl(title: string, url: string): string {
+export function getTwitterUrl(
+  text: string,
+  url: string,
+  hashtags?: string[]
+): string {
   return `https://twitter.com/share?url=${encodeURI(url)}&text=${encodeURI(
-    title
-  )}`
+    text
+  )}&hashtags=${hashtags?.join(',') ?? ''}`
 }
 
 export function getFacebookUrl(url: string): string {


### PR DESCRIPTION
## What

Twitterのシェアボタンを押した時、#Relaymがつくように変更した
実装の参考にしたWeb Intentの仕様は以下 
https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent

## Why

実際に使ってくれているのを見るのは楽しい