### PR TITLE
FontAwesomeを必要な分だけ読み込むように変更

### DIFF
--- a/components/atoms/ShareButtons.vue
+++ b/components/atoms/ShareButtons.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="share-buttons">
     <v-btn
-      class="fa-icon-button"
       fab
       dark
       icon
@@ -9,10 +8,9 @@
       :href="twitterUrl"
       aria-label="Twitterでシェア"
     >
-      <v-icon>fab fa-twitter</v-icon>
+      <v-font-awesome :icon="['fab', 'twitter']" />
     </v-btn>
     <v-btn
-      class="fa-icon-button"
       fab
       dark
       icon
@@ -20,10 +18,9 @@
       :href="facebookUrl"
       aria-label="Facebookでシェア"
     >
-      <v-icon>fab fa-facebook-f</v-icon>
+      <v-font-awesome :icon="['fab', 'facebook']" />
     </v-btn>
     <v-btn
-      class="fa-icon-button"
       fab
       dark
       icon
@@ -31,7 +28,7 @@
       :href="lineUrl"
       aria-label="LINEでシェア"
     >
-      <v-icon>fab fa-line</v-icon>
+      <v-font-awesome :icon="['fab', 'line']" />
     </v-btn>
   </div>
 </template>
@@ -39,9 +36,11 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import { getTwitterUrl, getFacebookUrl, getLineUrl } from '@/lib/share'
+import VFontAwesome from '~/components/atoms/VFontAwesome.vue'
 
 @Component({
-  name: 'ShareButtons'
+  name: 'ShareButtons',
+  components: { VFontAwesome }
 })
 export default class extends Vue {
   private shareUrl: string = location.origin
@@ -69,8 +68,5 @@ export default class extends Vue {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-.fa-icon-button i {
-  display: flex;
 }
 </style>

--- a/components/atoms/VFontAwesome.vue
+++ b/components/atoms/VFontAwesome.vue
@@ -13,6 +13,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
   name: 'VFontAwesome'
 })
 export default class extends Vue {
+  // クラス付与時に !== false としているのは、<v-font-awesome left ... />と書くと、left=""となるため
   @Prop({ default: false }) readonly left!: boolean
   @Prop({ default: false }) readonly right!: boolean
   @Prop({ required: true }) readonly icon!: string | string[]

--- a/components/atoms/VFontAwesome.vue
+++ b/components/atoms/VFontAwesome.vue
@@ -1,0 +1,33 @@
+<template>
+  <font-awesome-icon
+    class="v-font-awesome"
+    :class="{ left: left !== false, right: right !== false }"
+    :icon="icon"
+  />
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+@Component({
+  name: 'VFontAwesome'
+})
+export default class extends Vue {
+  @Prop({ default: false }) readonly left!: boolean
+  @Prop({ default: false }) readonly right!: boolean
+  @Prop({ required: true }) readonly icon!: string | string[]
+}
+</script>
+
+<style lang="scss" scoped>
+.v-font-awesome {
+  font-size: 24px;
+
+  &.left {
+    margin-right: 16px;
+  }
+  &.right {
+    margin-left: 16px;
+  }
+}
+</style>

--- a/components/molecules/InviteLinkBox.vue
+++ b/components/molecules/InviteLinkBox.vue
@@ -11,7 +11,7 @@
         aria-label="Twitterで招待"
         @click="handleClickTwitterShare"
       >
-        <v-icon>fab fa-twitter</v-icon>
+        <v-font-awesome :icon="['fab', 'twitter']" />
       </v-btn>
       <v-btn
         flat
@@ -20,7 +20,7 @@
         aria-label="LINEで招待"
         @click="handleClickLineShare"
       >
-        <v-icon>fab fa-line</v-icon>
+        <v-font-awesome :icon="['fab', 'line']" />
       </v-btn>
       <v-btn
         v-if="canShare"
@@ -29,7 +29,7 @@
         aria-label="URLを共有"
         @click="handleClickWebShare"
       >
-        <v-icon>fas fa-share-alt</v-icon>
+        <v-icon>share</v-icon>
       </v-btn>
       <v-btn depressed @click="handleClickCopy">コピー</v-btn>
     </v-layout>
@@ -49,12 +49,13 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 import { mapActions } from 'vuex'
 import copy from 'copy-to-clipboard'
 import QrCode from '@/components/atoms/QrCode.vue'
+import VFontAwesome from '@/components/atoms/VFontAwesome.vue'
 import { MessageType, SnackbarPayload } from '@/store/snackbar'
 import { getLineUrl, getTwitterUrl } from '@/lib/share'
 
 @Component({
   name: 'InviteLinkBox',
-  components: { QrCode },
+  components: { QrCode, VFontAwesome },
   methods: {
     ...mapActions('snackbar', ['showSnackbar'])
   }

--- a/components/organisms/ServiceDescription.vue
+++ b/components/organisms/ServiceDescription.vue
@@ -113,7 +113,7 @@
           href="https://github.com/camphor-/relaym-client"
           round
         >
-          <v-icon left dark>fab fa-github</v-icon>
+          <v-font-awesome :icon="['fab', 'github']" left />
           relaym-client
         </v-btn>
         <v-btn
@@ -122,7 +122,7 @@
           href="https://github.com/camphor-/relaym-server"
           round
         >
-          <v-icon left dark>fab fa-github</v-icon>
+          <v-font-awesome :icon="['fab', 'github']" left />
           relaym-server
         </v-btn>
       </div>
@@ -137,10 +137,12 @@ import ServiceFeature from '@/components/atoms/ServiceFeature.vue'
 import HowtoStepHeader from '@/components/atoms/HowtoStepHeader.vue'
 import LoginButton from '@/components/atoms/LoginButton.vue'
 import ShareButtons from '@/components/atoms/ShareButtons.vue'
+import VFontAwesome from '~/components/atoms/VFontAwesome.vue'
 
 @Component({
   name: 'ServiceDescription',
   components: {
+    VFontAwesome,
     ShareButtons,
     HowtoStepHeader,
     ServiceFeature,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -96,7 +96,7 @@ const nuxtConfig: NuxtConfig = {
   /*
    ** Global CSS
    */
-  css: [],
+  css: ['@fortawesome/fontawesome-svg-core/styles.css'],
 
   /*
    ** Plugins to load before mounting the App

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.14.0",
-    "@fortawesome/fontawesome-free-brands": "^5.0.13",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@fortawesome/fontawesome-free-brands": "^5.0.13",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
+    "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^0.1.10",
     "@nuxt/typescript-runtime": "^1.0.0",
     "@nuxtjs/google-analytics": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@fortawesome/fontawesome-free-brands": "^5.0.13",
+    "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/vue-fontawesome": "^0.1.10",
     "@nuxt/typescript-runtime": "^1.0.0",
     "@nuxtjs/google-analytics": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@fortawesome/fontawesome-free-brands": "^5.0.13",
+    "@fortawesome/vue-fontawesome": "^0.1.10",
     "@nuxt/typescript-runtime": "^1.0.0",
     "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/pwa": "^3.0.0-beta.16",

--- a/plugins/loadFontAwesome.ts
+++ b/plugins/loadFontAwesome.ts
@@ -1,1 +1,15 @@
-import '@fortawesome/fontawesome-free/css/all.css'
+// cf) https://github.com/FortAwesome/vue-fontawesome#integrating-with-other-tools-and-frameworks
+import Vue from 'vue'
+import { library, config } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+
+// This is important, we are going to let Nuxt.js worry about the CSS
+config.autoAddCss = false
+
+// You can add your icons directly in this plugin. See other examples for how you
+// can add other styles or just individual icons.
+library.add(fab)
+
+// Register the component globally
+Vue.component('font-awesome-icon', FontAwesomeIcon)

--- a/plugins/loadFontAwesome.ts
+++ b/plugins/loadFontAwesome.ts
@@ -2,14 +2,19 @@
 import Vue from 'vue'
 import { library, config } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { fab } from '@fortawesome/free-brands-svg-icons'
+import {
+  faTwitter,
+  faFacebook,
+  faLine,
+  faGithub
+} from '@fortawesome/free-brands-svg-icons'
 
 // This is important, we are going to let Nuxt.js worry about the CSS
 config.autoAddCss = false
 
 // You can add your icons directly in this plugin. See other examples for how you
 // can add other styles or just individual icons.
-library.add(fab)
+library.add(faTwitter, faFacebook, faLine, faGithub)
 
 // Register the component globally
 Vue.component('font-awesome-icon', FontAwesomeIcon)

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,6 +889,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz#4336c4b06d0b5608ff1215464b66fcf9f4795284"
   integrity sha512-ego8jRVSHfq/iq4KRZJKQeUAdi3ZjGNrqw4oPN3fNdvTBnLCSntwVCnc37bsAJP9UB8MhrTfPnZYxkv2vpS4pg==
 
+"@fortawesome/fontawesome-common-types@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
+  integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==
+
 "@fortawesome/fontawesome-free-brands@^5.0.13":
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-brands/-/fontawesome-free-brands-5.0.13.tgz#4d15ff4e1e862d5e4a4df3654f8e8acbd47e9c09"
@@ -900,6 +905,13 @@
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
   integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
+
+"@fortawesome/fontawesome-svg-core@^1.2.30":
+  version "1.2.30"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz#f56dc6791861fe5d1af04fb8abddb94658c576db"
+  integrity sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.30"
 
 "@fortawesome/vue-fontawesome@^0.1.10":
   version "0.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,6 +901,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
   integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
 
+"@fortawesome/vue-fontawesome@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34"
+  integrity sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,6 +913,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.30"
 
+"@fortawesome/free-brands-svg-icons@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.14.0.tgz#98555518ba41bdff82fbae2f4d1bc36cd3b1c043"
+  integrity sha512-WsqPFTvJFI7MYkcy0jeFE2zY+blC4OrnB9MJOcn1NxRXT/sSfEEhrI7CwzIkiYajLiVDBKWeErYOvpsMeodmCQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.30"
+
 "@fortawesome/vue-fontawesome@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,27 +884,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@fortawesome/fontawesome-common-types@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz#4336c4b06d0b5608ff1215464b66fcf9f4795284"
-  integrity sha512-ego8jRVSHfq/iq4KRZJKQeUAdi3ZjGNrqw4oPN3fNdvTBnLCSntwVCnc37bsAJP9UB8MhrTfPnZYxkv2vpS4pg==
-
 "@fortawesome/fontawesome-common-types@^0.2.30":
   version "0.2.30"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
   integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==
-
-"@fortawesome/fontawesome-free-brands@^5.0.13":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-brands/-/fontawesome-free-brands-5.0.13.tgz#4d15ff4e1e862d5e4a4df3654f8e8acbd47e9c09"
-  integrity sha512-xC/sEPpfcJPvUbud2GyscLCLQlE2DVBYaTHVwuyVGliYBdYejSEYMINU8FN5A0xhO68yCbpCfMlBv6Gqby+jww==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.1.7"
-
-"@fortawesome/fontawesome-free@^5.14.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
-  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
 
 "@fortawesome/fontawesome-svg-core@^1.2.30":
   version "1.2.30"


### PR DESCRIPTION
## What

Vuetify 1.xでFontAwesomeを使う場合、全アイコンのcssを読み込みv-iconで使う方法が案内されていた。
しかし、Tree Shakingが効かず、全アイコンのSVGが吐き出されるため、配信サイズにとても影響する。

そのため、v-iconの代わりにvue-fontawesomeを用いて同等の表示を実現し、ビルド後のサイズを減らした。

<details>
<summary>変更前</summary>

```
Hash: 82dc2ddbae3584d1f10b
Version: webpack 4.44.1
Time: 19394ms
Built at: 2020-08-05 3:53:28
                                      Asset      Size  Chunks                                Chunk Names
             ../server/client.manifest.json    42 KiB          [emitted]
                              10.cbabc93.js   4.3 KiB      10  [emitted] [immutable]
                                   LICENSES   1.4 KiB          [emitted]
                             app.36984f5.js  72.1 KiB       2  [emitted] [immutable]         app
                     commons/app.6518e20.js   179 KiB       3  [emitted] [immutable]         commons/app
 commons/index~sessions.id.index.195bc92.js    28 KiB       0  [emitted] [immutable]         commons/index~sessions.id.index
commons/index~sessions.id.search.52e59f9.js  53.3 KiB       1  [emitted] [immutable]         commons/index~sessions.id.search
            fonts/fa-brands-400.085b1dd.ttf   131 KiB          [emitted]
            fonts/fa-brands-400.0fabb66.eot   131 KiB          [emitted]
          fonts/fa-brands-400.cac68c8.woff2  75.6 KiB          [emitted]
           fonts/fa-brands-400.dc0bd02.woff  88.5 KiB          [emitted]
          fonts/fa-regular-400.05b53be.woff  16.4 KiB          [emitted]
           fonts/fa-regular-400.1a78af4.ttf  33.3 KiB          [emitted]
         fonts/fa-regular-400.3a3398a.woff2  13.3 KiB          [emitted]
           fonts/fa-regular-400.ad3a7c0.eot  33.5 KiB          [emitted]
             fonts/fa-solid-900.781e85b.ttf   199 KiB          [emitted]
             fonts/fa-solid-900.89bd2e3.eot   199 KiB          [emitted]
           fonts/fa-solid-900.c500da1.woff2  78.3 KiB          [emitted]
            fonts/fa-solid-900.ee09ad7.woff   102 KiB          [emitted]
                        img/add.6701fbd.svg  5.67 KiB          [emitted]
              img/fa-brands-400.ccfdb9d.svg   713 KiB          [emitted]              [big]
             img/fa-regular-400.e75dfd9.svg   141 KiB          [emitted]
               img/fa-solid-900.03ba7cb.svg   893 KiB          [emitted]              [big]
                       img/ohno.a1daf7e.svg  2.16 KiB          [emitted]
                      img/share.5aff8ff.svg  2.67 KiB          [emitted]
            img/spotify_premium.9a803fe.svg  3.48 KiB          [emitted]
                      img/step1.2570455.png  19.8 KiB          [emitted]
                      img/step2.7e1981a.png  36.3 KiB          [emitted]
                      img/step3.9d87db3.png  9.67 KiB          [emitted]
                  img/text_logo.3caae5a.svg  2.06 KiB          [emitted]
                           index.892e8c8.js  38.6 KiB       4  [emitted] [immutable]         index
                     manifest.9a5d151b.json  1.03 KiB          [emitted]
                     pages/terms.ff66d5f.js  12.8 KiB       5  [emitted] [immutable]         pages/terms
                         runtime.1a858cb.js  2.52 KiB       6  [emitted] [immutable]         runtime
               sessions.id.index.b5eb1d6.js  96.6 KiB       7  [emitted] [immutable]         sessions.id.index
              sessions.id.search.2639174.js  21.3 KiB       8  [emitted] [immutable]         sessions.id.search
                     vendors~app.82d842b.js   373 KiB       9  [emitted] [immutable]  [big]  vendors~app
 + 1 hidden asset
Entrypoint app = runtime.1a858cb.js commons/app.6518e20.js vendors~app.82d842b.js app.36984f5.js
```

</details>

<details>
<summary>変更後</summary>

```
Hash: c33269882509aa13b0eb
Version: webpack 4.44.1
Time: 20786ms
Built at: 2020-08-05 3:55:33
                                      Asset      Size  Chunks                                Chunk Names
             ../server/client.manifest.json  28.8 KiB          [emitted]
                              10.ea01eb0.js   4.3 KiB      10  [emitted] [immutable]
                                   LICENSES   1.4 KiB          [emitted]
                             app.edc2158.js  72.2 KiB       2  [emitted] [immutable]         app
                     commons/app.6d06d47.js   179 KiB       3  [emitted] [immutable]         commons/app
 commons/index~sessions.id.index.b604c7c.js  29.4 KiB       0  [emitted] [immutable]         commons/index~sessions.id.index
commons/index~sessions.id.search.d3ee31a.js  53.3 KiB       1  [emitted] [immutable]         commons/index~sessions.id.search
                        img/add.6701fbd.svg  5.67 KiB          [emitted]
                       img/ohno.a1daf7e.svg  2.16 KiB          [emitted]
                      img/share.5aff8ff.svg  2.67 KiB          [emitted]
            img/spotify_premium.9a803fe.svg  3.48 KiB          [emitted]
                      img/step1.2570455.png  19.8 KiB          [emitted]
                      img/step2.7e1981a.png  36.3 KiB          [emitted]
                      img/step3.9d87db3.png  9.67 KiB          [emitted]
                  img/text_logo.3caae5a.svg  2.06 KiB          [emitted]
                           index.23ac73c.js  38.6 KiB       4  [emitted] [immutable]         index
                     manifest.9a5d151b.json  1.03 KiB          [emitted]
                     pages/terms.2d3f20f.js  12.8 KiB       5  [emitted] [immutable]         pages/terms
                         runtime.131aa8b.js  2.52 KiB       6  [emitted] [immutable]         runtime
               sessions.id.index.b67da3d.js  96.7 KiB       7  [emitted] [immutable]         sessions.id.index
              sessions.id.search.c346bea.js  21.3 KiB       8  [emitted] [immutable]         sessions.id.search
                     vendors~app.01a6321.js   356 KiB       9  [emitted] [immutable]  [big]  vendors~app
 + 1 hidden asset
Entrypoint app = runtime.131aa8b.js commons/app.6d06d47.js vendors~app.01a6321.js app.edc2158.js
```

</details>